### PR TITLE
change defArgs method because of the bug in CompositeInstr evaluation

### DIFF
--- a/Instr/Instr.sc
+++ b/Instr/Instr.sc
@@ -1,5 +1,4 @@
 
-
 Instr  {
 
 	classvar <dir;
@@ -222,7 +221,7 @@ Instr  {
 	maxArgs { ^this.argsSize }
 	argsSize { ^func.def.argNames.size }
 	argNames { ^(func.def.argNames ? []).asList }
-	defArgs { ^(func.def.prototypeFrame ? []).asList }
+	defArgs { ^(func.def.prototypeFrame ? []).copyRange(0,this.argNames.size-1).asList }
 
 	argNameAt { arg i;
 		var nn;


### PR DESCRIPTION
CompositeInstr uses defArgs to determ the default arguments 
but prototypeFrame includes also variable definitions: so only the range of the variables should be included in the defArgs List.
